### PR TITLE
Fix of date graph-related operations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,7 @@ fn cli() -> Command {
                 .required(false))
             .arg(arg!(-p --parent <ID> "Assigns this node to a parent")
                 .required_unless_present("root")
+                .required_unless_present("date")
             )
             .arg(arg!(<message> "This node's message"))
         )


### PR DESCRIPTION
This PR addresses some date graph-related issues:

- `--parent` being mandatory if `--date` is used when adding a node.
- After deleting a date (root) node, the entry is still retained under the `graph.dates` array on the data file, even though its node item counterpart has been deleted.
