### PR TITLE
Implement Configuration Support for CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,7 @@ dependencies = [
  "serde",
  "serde_yaml_ng",
  "thiserror",
+ "toml",
  "tuesday_core",
  "yaml-rust2",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,6 +18,7 @@ yaml-rust2 = "0.10.0"
 rand = "0.9.0"
 chrono = "0.4.40"
 parse_datetime = "0.8.0"
+toml = "0.8.20"
 
 [[bin]]
 name = "tuecli"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,7 +1,6 @@
 mod defaults;
 
-use chrono::{Local, NaiveDate};
-use defaults::*;
+pub use defaults::*;
 
 use std::fmt::Display;
 use std::fs::OpenOptions;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -64,10 +64,9 @@ pub enum ReadError {
 
 /// Parses core configurations from a toml table
 /// Any missing or malformed values will be replaced with defaults
-/// See
 #[allow(unused_mut, unused_variables)]
-pub fn parse_config(toml: &toml::Table) -> CoreConfig {
-    let mut conf = CoreConfig::new();
+pub fn parse_config(toml: &toml::Table) -> CliConfig {
+    let mut conf = CliConfig::new();
 
     // Core configurations here
     // TODO: Populate this and remove the warning allowance
@@ -75,22 +74,22 @@ pub fn parse_config(toml: &toml::Table) -> CoreConfig {
     conf
 }
 
-pub fn try_parse_config(toml: &toml::Table) -> Result<CoreConfig, ParseError> {
+pub fn try_parse_config(toml: &toml::Table) -> Result<CliConfig, ParseError> {
     todo!("try_parse_config is unimplemented!");
 }
 
 #[derive(Debug, Error)]
 pub enum ParseError {}
 
-pub struct CoreConfig {}
+pub struct CliConfig {}
 
-impl CoreConfig {
+impl CliConfig {
     pub fn new() -> Self {
         Self {}
     }
 }
 
-impl Default for CoreConfig {
+impl Default for CliConfig {
     fn default() -> Self {
         Self::new()
     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,11 +1,146 @@
+mod defaults;
+
+use defaults::*;
+
 use std::fs::OpenOptions;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
+use crate::display::Color;
+use crate::AppResult;
+
+pub type ConfigParseResult<T> = Result<T, ConfigReadError>;
+
 /// The default config file name
-pub const DEFAULT_FILENAME: &str = ".tueconf";
+pub const DEFAULT_FILENAME: &str = ".tueconf.toml";
+
+/// Represents an error during reading a config file
+#[derive(Debug, Error)]
+pub enum ConfigReadError {
+    #[error("File does not exist: {0}")]
+    NonexistantFile(PathBuf),
+
+    #[error("I/O error: {0}")]
+    IOError(#[from] std::io::Error),
+
+    #[error("TOML Deserialization error: {0}")]
+    TOMLDeserializeErr(#[from] toml::de::Error),
+
+    #[error("Color parse error: {0}")]
+    ColorParseErr(String),
+}
+
+pub struct GraphConfig {
+    pub(crate) auto_clean: bool,
+}
+
+impl Default for GraphConfig {
+    fn default() -> Self {
+        Self {
+            auto_clean: DEFAULT_GRAPH_AUTO_CLEAN
+        }
+    }
+}
+
+pub struct Icon {
+    pub(crate) value: String,
+    pub(crate) color: Color
+}
+
+impl Icon {
+    pub fn colorize<T: Into<Color>>(mut self, color: T) -> Self {
+        self.color = color.into();
+        self
+    }
+}
+
+impl From<&str> for Icon {
+    fn from(value: &str) -> Self {
+        Icon {
+            value: value.to_string(),
+            color: Color::default()
+        }
+    }
+}
+
+pub struct DisplayIconConfig {
+    pub(crate) arm: Icon,
+    pub(crate) arm_last: Icon,
+    pub(crate) arm_multiparent: Icon,
+    pub(crate) arm_multiparent_last: Icon,
+    pub(crate) arm_bar: Icon,
+
+    pub(crate) node_none: Icon,
+    pub(crate) node_checked: Icon,
+    pub(crate) node_partial: Icon,
+    pub(crate) node_pseudo: Icon,
+    pub(crate) node_date: Icon,
+}
+
+impl Default for DisplayIconConfig {
+    fn default() -> Self {
+        Self {
+            arm: Icon::from(DEFAULT_ICON_ARM).colorize(DEFAULT_COLOR_ARM),
+            arm_last: Icon::from(DEFAULT_ICON_ARM_LAST).colorize(DEFAULT_COLOR_ARM_LAST),
+            arm_multiparent: Icon::from(DEFAULT_ICON_ARM_MULTIPARENT).colorize(DEFAULT_COLOR_ARM_MULTIPARENT),
+            arm_multiparent_last: Icon::from(DEFAULT_ICON_ARM_MULTIPARENT_LAST).colorize(DEFAULT_COLOR_ARM_MULTIPARENT_LAST),
+            arm_bar: Icon::from(DEFAULT_ICON_ARM_BAR).colorize(DEFAULT_COLOR_ARM_BAR),
+
+            node_none: Icon::from(DEFAULT_ICON_NODE_NONE).colorize(DEFAULT_COLOR_NODE_NONE),
+            node_checked: Icon::from(DEFAULT_ICON_NODE_CHECKED).colorize(DEFAULT_COLOR_NODE_CHECKED),
+            node_partial: Icon::from(DEFAULT_ICON_NODE_PARTIAL).colorize(DEFAULT_COLOR_NODE_PARTIAL),
+            node_pseudo: Icon::from(DEFAULT_ICON_NODE_PSEUDO).colorize(DEFAULT_COLOR_NODE_PSEUDO),
+            node_date: Icon::from(DEFAULT_ICON_NODE_DATE).colorize(DEFAULT_COLOR_NODE_DATE),
+        }
+    }
+
+}
+
+pub struct CalendarConfig {
+    pub(crate) heatmap_palette: [Color; 5]
+}
+
+impl Default for CalendarConfig {
+    fn default() -> Self {
+        Self {
+            heatmap_palette: DEFAULT_HEATMAP_PALETTE
+        }
+    }
+}
+
+pub struct DisplayConfig {
+    pub(crate) date_fmt: String,
+    pub(crate) show_connections: bool,
+    pub(crate) icons: DisplayIconConfig,
+    pub(crate) calendar_config: CalendarConfig
+}
+
+impl Default for DisplayConfig {
+    fn default() -> Self {
+        Self {
+            show_connections: DEFAULT_SHOW_CONNECTIONS,
+            date_fmt: DEFAULT_DATE_FORMAT.to_string(),
+            calendar_config: CalendarConfig::default(),
+            icons: DisplayIconConfig::default()
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct CliConfig {
+    pub(crate) graph: GraphConfig,
+    pub(crate) display: DisplayConfig,
+}
+
+impl CliConfig {
+    pub fn new() -> Self {
+        Self {
+            ..Default::default()
+        }
+    }
+}
 
 /// Returns the default config file located at the user's home directory
 /// If the file does not exist then it returns `None`
@@ -36,9 +171,9 @@ pub fn get_default_at(mut pathbuf: PathBuf) -> Option<PathBuf> {
 }
 
 /// Parses a file at path into a toml table
-pub fn read_file(path: &Path) -> Result<toml::Table, ReadError> {
+pub fn read_file(path: &Path) -> ConfigParseResult<toml::Table> {
     if !path.exists() {
-        return Err(ReadError::NonexistantFile(path.to_path_buf()));
+        return Err(ConfigReadError::NonexistantFile(path.to_path_buf()));
     }
 
     let mut file = OpenOptions::new().read(true).open(path)?;
@@ -49,48 +184,231 @@ pub fn read_file(path: &Path) -> Result<toml::Table, ReadError> {
     Ok(string.parse::<toml::Table>()?)
 }
 
-/// Represents an error during reading a config file
-#[derive(Debug, Error)]
-pub enum ReadError {
-    #[error("File does not exist: {0}")]
-    NonexistantFile(PathBuf),
-
-    #[error("I/O error: {0}")]
-    IOError(#[from] std::io::Error),
-
-    #[error("TOML Deserialization error: {0}")]
-    TOMLDeserializeErr(#[from] toml::de::Error),
-}
+const KEY_GRAPH: &str = "graph";
+const KEY_DISPLAY: &str = "display";
+const KEY_AUTO_CLEAN: &str = "auto_clean";
+const KEY_DATE_FMT: &str = "date_fmt";
+const KEY_SHOW_CONNECTIONS: &str = "show_connections";
+const KEY_DISPLAY_ICONS: &str = "icons";
+const KEY_DISPLAY_ICON: &str = "icon";
+const KEY_DISPLAY_COLOR: &str = "color";
+const KEY_DISPLAY_ICONS_ARM: &str = "arm";
+const KEY_DISPLAY_ICONS_ARM_LAST: &str = "arm_last";
+const KEY_DISPLAY_ICONS_ARM_MULTIPARENT: &str = "arm_multiparent";
+const KEY_DISPLAY_ICONS_ARM_MULTIPARENT_LAST: &str = "arm_multiparent_last";
+const KEY_DISPLAY_ICONS_ARM_BAR: &str = "arm_bar";
+const KEY_DISPLAY_ICONS_NODE_NONE: &str = "node_none";
+const KEY_DISPLAY_ICONS_NODE_CHECKED: &str = "node_checked";
+const KEY_DISPLAY_ICONS_NODE_PARTIAL: &str = "node_partial";
+const KEY_DISPLAY_ICONS_NODE_PSEUDO: &str = "node_pseudo";
+const KEY_DISPLAY_ICONS_NODE_DATE: &str = "node_date";
+const KEY_DISPLAY_CALENDAR: &str = "calendar";
+const KEY_DISPLAY_CALENDAR_HEATMAP: &str = "heatmap";
+const KEY_DISPLAY_CALENDAR_HEATMAP_PALETTE: &str = "palette";
 
 /// Parses core configurations from a toml table
-/// Any missing or malformed values will be replaced with defaults
-#[allow(unused_mut, unused_variables)]
-pub fn parse_config(toml: &toml::Table) -> CliConfig {
+/// Any missing or malformed values will be replaced with defaults.
+pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
     let mut conf = CliConfig::new();
 
-    // Core configurations here
-    // TODO: Populate this and remove the warning allowance
+    // TODO: um wtf
 
-    conf
-}
-
-pub fn try_parse_config(toml: &toml::Table) -> Result<CliConfig, ParseError> {
-    todo!("try_parse_config is unimplemented!");
-}
-
-#[derive(Debug, Error)]
-pub enum ParseError {}
-
-pub struct CliConfig {}
-
-impl CliConfig {
-    pub fn new() -> Self {
-        Self {}
+    // Graph configuration
+    if let Some(graph_cfg) = toml.get(KEY_GRAPH) {
+        if let Some(val) = graph_cfg.get(KEY_AUTO_CLEAN).and_then(toml::Value::as_bool) {
+            conf.graph.auto_clean = val;
+        }
     }
+
+    // Display configuration
+    if let Some(display_cfg) = toml.get(KEY_DISPLAY) {
+        if let Some(val) = display_cfg.get(KEY_DATE_FMT).and_then(toml::Value::as_str) {
+            conf.display.date_fmt = val.to_string();
+        }
+
+        if let Some(val) = display_cfg.get(KEY_SHOW_CONNECTIONS).and_then(toml::Value::as_bool) {
+            conf.display.show_connections = val;
+        }
+
+        // Icons configuration
+        if let Some(icons) = display_cfg.get(KEY_DISPLAY_ICONS) {
+            if let Some(arm) = icons.get(KEY_DISPLAY_ICONS_ARM) {
+                if let Some(val) = arm.get(KEY_DISPLAY_ICON).and_then(toml::Value::as_str) {
+                    conf.display.icons.arm.value = val.to_string();
+                }
+
+                if let Some(val) = arm.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
+                    conf.display.icons.arm.color = Color::from_hex(val)
+                        .map_err(|_| ConfigReadError::ColorParseErr(format!(
+                            "Invalid color for {}{}{}: {}",
+                            KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_ARM, val
+                        )))?;
+                }
+            }
+
+            if let Some(arm_last) = icons.get(KEY_DISPLAY_ICONS_ARM_LAST) {
+                if let Some(val) = arm_last.get(KEY_DISPLAY_ICON).and_then(toml::Value::as_str) {
+                    conf.display.icons.arm_last.value = val.to_string();
+                }
+
+                if let Some(val) = arm_last.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
+                    conf.display.icons.arm_last.color = Color::from_hex(val)
+                        .map_err(|_| ConfigReadError::ColorParseErr(format!(
+                            "Invalid color for {}{}{}: {}",
+                            KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_ARM_LAST, val
+                        )))?;
+                }
+            }
+
+            if let Some(arm_multiparent) = icons.get(KEY_DISPLAY_ICONS_ARM_MULTIPARENT) {
+                if let Some(val) = arm_multiparent.get(KEY_DISPLAY_ICON).and_then(toml::Value::as_str) {
+                    conf.display.icons.arm_multiparent.value = val.to_string();
+                }
+
+                if let Some(val) = arm_multiparent.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
+                    conf.display.icons.arm_multiparent.color = Color::from_hex(val)
+                        .map_err(|_| ConfigReadError::ColorParseErr(format!(
+                            "Invalid color for {}{}{}: {}",
+                            KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_ARM_MULTIPARENT, val
+                        )))?;
+                }
+            }
+
+            if let Some(arm_multiparent_last) = icons.get(KEY_DISPLAY_ICONS_ARM_MULTIPARENT_LAST) {
+                if let Some(val) = arm_multiparent_last.get(KEY_DISPLAY_ICON).and_then(toml::Value::as_str) {
+                    conf.display.icons.arm_multiparent_last.value = val.to_string();
+                }
+
+                if let Some(val) = arm_multiparent_last.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
+                    conf.display.icons.arm_multiparent_last.color = Color::from_hex(val)
+                        .map_err(|_| ConfigReadError::ColorParseErr(format!(
+                            "Invalid color for {}{}{}: {}",
+                            KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_ARM_MULTIPARENT_LAST, val
+                        )))?;
+                }
+            }
+
+            if let Some(arm_bar) = icons.get(KEY_DISPLAY_ICONS_ARM_BAR) {
+                if let Some(val) = arm_bar.get(KEY_DISPLAY_ICON).and_then(toml::Value::as_str) {
+                    conf.display.icons.arm_bar.value = val.to_string();
+                }
+
+                if let Some(val) = arm_bar.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
+                    conf.display.icons.arm_bar.color = Color::from_hex(val)
+                        .map_err(|_| ConfigReadError::ColorParseErr(format!(
+                            "Invalid color for {}{}{}: {}",
+                            KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_ARM_BAR, val
+                        )))?;
+                }
+            }
+
+            if let Some(node_none) = icons.get(KEY_DISPLAY_ICONS_NODE_NONE) {
+                if let Some(val) = node_none.get(KEY_DISPLAY_ICON).and_then(toml::Value::as_str) {
+                    conf.display.icons.node_none.value = val.to_string();
+                }
+
+                if let Some(val) = node_none.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
+                    conf.display.icons.node_none.color = Color::from_hex(val)
+                        .map_err(|_| ConfigReadError::ColorParseErr(format!(
+                            "Invalid color for {}{}{}: {}",
+                            KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_NODE_NONE, val
+                        )))?;
+                }
+            }
+
+            if let Some(node_checked) = icons.get(KEY_DISPLAY_ICONS_NODE_CHECKED) {
+                if let Some(val) = node_checked.get(KEY_DISPLAY_ICON).and_then(toml::Value::as_str) {
+                    conf.display.icons.node_checked.value = val.to_string();
+                }
+
+                if let Some(val) = node_checked.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
+                    conf.display.icons.node_checked.color = Color::from_hex(val)
+                        .map_err(|_| ConfigReadError::ColorParseErr(format!(
+                            "Invalid color for {}{}{}: {}",
+                            KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_NODE_CHECKED, val
+                        )))?;
+                }
+            }
+
+            if let Some(node_partial) = icons.get(KEY_DISPLAY_ICONS_NODE_PARTIAL) {
+                if let Some(val) = node_partial.get(KEY_DISPLAY_ICON).and_then(toml::Value::as_str) {
+                    conf.display.icons.node_partial.value = val.to_string();
+                }
+
+                if let Some(val) = node_partial.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
+                    conf.display.icons.node_partial.color = Color::from_hex(val)
+                        .map_err(|_| ConfigReadError::ColorParseErr(format!(
+                            "Invalid color for {}{}{}: {}",
+                            KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_NODE_PARTIAL, val
+                        )))?;
+                }
+            }
+
+            if let Some(node_pseudo) = icons.get(KEY_DISPLAY_ICONS_NODE_PSEUDO) {
+                if let Some(val) = node_pseudo.get(KEY_DISPLAY_ICON).and_then(toml::Value::as_str) {
+                    conf.display.icons.node_pseudo.value = val.to_string();
+                }
+
+                if let Some(val) = node_pseudo.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
+                    conf.display.icons.node_pseudo.color = Color::from_hex(val)
+                        .map_err(|_| ConfigReadError::ColorParseErr(format!(
+                            "Invalid color for {}{}{}: {}",
+                            KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_NODE_PSEUDO, val
+                        )))?;
+                }
+            }
+
+            if let Some(node_date) = icons.get(KEY_DISPLAY_ICONS_NODE_DATE) {
+                if let Some(val) = node_date.get(KEY_DISPLAY_ICON).and_then(toml::Value::as_str) {
+                    conf.display.icons.node_date.value = val.to_string();
+                }
+
+                if let Some(val) = node_date.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
+                    conf.display.icons.node_date.color = Color::from_hex(val)
+                        .map_err(|_| ConfigReadError::ColorParseErr(format!(
+                            "Invalid color for {}{}{}: {}",
+                            KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_NODE_DATE, val
+                        )))?;
+                }
+            }
+        }
+
+        // Calendar configuration
+        if let Some(calendar_cfg) = display_cfg.get(KEY_DISPLAY_CALENDAR) {
+            if let Some(heatmap) = calendar_cfg.get(KEY_DISPLAY_CALENDAR_HEATMAP) {
+                if let Some(val) = heatmap.get(KEY_DISPLAY_CALENDAR_HEATMAP_PALETTE).and_then(toml::Value::as_array) {
+                    for (i, color_str) in val.iter().enumerate() {
+                        if let Some(color) = color_str.as_str() {
+                            if let Ok(parsed_color) = Color::from_hex(color) {
+                                conf.display.calendar_config.heatmap_palette[i] = parsed_color;
+                            } else {
+                                return Err(ConfigReadError::ColorParseErr(format!(
+                                    "Invalid color in heatmap palette: {}", color
+                                )).into());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(conf)
 }
 
-impl Default for CliConfig {
-    fn default() -> Self {
-        Self::new()
-    }
+
+pub fn get_config() -> AppResult<CliConfig> {
+    let conf;
+    if let Some(path) = get_home_default() {
+        if let Some(path) = get_default_at(path) {
+            let toml = read_file(&path)?;
+            conf = parse_config(&toml)?;
+        } else {
+        conf = CliConfig::default();
+        }
+    } else {
+        conf = CliConfig::default();
+    };
+
+    Ok(conf)
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,5 +1,6 @@
 mod defaults;
 
+use chrono::{Local, NaiveDate};
 use defaults::*;
 
 use std::fs::OpenOptions;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -3,6 +3,7 @@ mod defaults;
 use chrono::{Local, NaiveDate};
 use defaults::*;
 
+use std::fmt::Display;
 use std::fs::OpenOptions;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -54,6 +55,12 @@ impl Icon {
     pub fn colorize<T: Into<Color>>(mut self, color: T) -> Self {
         self.color = color.into();
         self
+    }
+}
+
+impl Display for Icon {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value)
     }
 }
 
@@ -239,7 +246,7 @@ pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
                 }
 
                 if let Some(val) = arm.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
-                    conf.display.icons.arm.color = Color::from_hex(val)
+                    conf.display.icons.arm.color = Color::from_str(val)
                         .map_err(|_| ConfigReadError::ColorParseErr(format!(
                             "Invalid color for {}{}{}: {}",
                             KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_ARM, val
@@ -253,7 +260,7 @@ pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
                 }
 
                 if let Some(val) = arm_last.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
-                    conf.display.icons.arm_last.color = Color::from_hex(val)
+                    conf.display.icons.arm_last.color = Color::from_str(val)
                         .map_err(|_| ConfigReadError::ColorParseErr(format!(
                             "Invalid color for {}{}{}: {}",
                             KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_ARM_LAST, val
@@ -267,7 +274,7 @@ pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
                 }
 
                 if let Some(val) = arm_multiparent.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
-                    conf.display.icons.arm_multiparent.color = Color::from_hex(val)
+                    conf.display.icons.arm_multiparent.color = Color::from_str(val)
                         .map_err(|_| ConfigReadError::ColorParseErr(format!(
                             "Invalid color for {}{}{}: {}",
                             KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_ARM_MULTIPARENT, val
@@ -281,7 +288,7 @@ pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
                 }
 
                 if let Some(val) = arm_multiparent_last.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
-                    conf.display.icons.arm_multiparent_last.color = Color::from_hex(val)
+                    conf.display.icons.arm_multiparent_last.color = Color::from_str(val)
                         .map_err(|_| ConfigReadError::ColorParseErr(format!(
                             "Invalid color for {}{}{}: {}",
                             KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_ARM_MULTIPARENT_LAST, val
@@ -295,7 +302,7 @@ pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
                 }
 
                 if let Some(val) = arm_bar.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
-                    conf.display.icons.arm_bar.color = Color::from_hex(val)
+                    conf.display.icons.arm_bar.color = Color::from_str(val)
                         .map_err(|_| ConfigReadError::ColorParseErr(format!(
                             "Invalid color for {}{}{}: {}",
                             KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_ARM_BAR, val
@@ -309,7 +316,7 @@ pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
                 }
 
                 if let Some(val) = node_none.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
-                    conf.display.icons.node_none.color = Color::from_hex(val)
+                    conf.display.icons.node_none.color = Color::from_str(val)
                         .map_err(|_| ConfigReadError::ColorParseErr(format!(
                             "Invalid color for {}{}{}: {}",
                             KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_NODE_NONE, val
@@ -323,7 +330,7 @@ pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
                 }
 
                 if let Some(val) = node_checked.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
-                    conf.display.icons.node_checked.color = Color::from_hex(val)
+                    conf.display.icons.node_checked.color = Color::from_str(val)
                         .map_err(|_| ConfigReadError::ColorParseErr(format!(
                             "Invalid color for {}{}{}: {}",
                             KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_NODE_CHECKED, val
@@ -337,7 +344,7 @@ pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
                 }
 
                 if let Some(val) = node_partial.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
-                    conf.display.icons.node_partial.color = Color::from_hex(val)
+                    conf.display.icons.node_partial.color = Color::from_str(val)
                         .map_err(|_| ConfigReadError::ColorParseErr(format!(
                             "Invalid color for {}{}{}: {}",
                             KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_NODE_PARTIAL, val
@@ -351,7 +358,7 @@ pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
                 }
 
                 if let Some(val) = node_pseudo.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
-                    conf.display.icons.node_pseudo.color = Color::from_hex(val)
+                    conf.display.icons.node_pseudo.color = Color::from_str(val)
                         .map_err(|_| ConfigReadError::ColorParseErr(format!(
                             "Invalid color for {}{}{}: {}",
                             KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_NODE_PSEUDO, val
@@ -365,7 +372,7 @@ pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
                 }
 
                 if let Some(val) = node_date.get(KEY_DISPLAY_COLOR).and_then(toml::Value::as_str) {
-                    conf.display.icons.node_date.color = Color::from_hex(val)
+                    conf.display.icons.node_date.color = Color::from_str(val)
                         .map_err(|_| ConfigReadError::ColorParseErr(format!(
                             "Invalid color for {}{}{}: {}",
                             KEY_DISPLAY, KEY_DISPLAY_ICONS, KEY_DISPLAY_ICONS_NODE_DATE, val
@@ -380,7 +387,7 @@ pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
                 if let Some(val) = heatmap.get(KEY_DISPLAY_CALENDAR_HEATMAP_PALETTE).and_then(toml::Value::as_array) {
                     for (i, color_str) in val.iter().enumerate() {
                         if let Some(color) = color_str.as_str() {
-                            if let Ok(parsed_color) = Color::from_hex(color) {
+                            if let Ok(parsed_color) = Color::from_str(color) {
                                 conf.display.calendar_config.heatmap_palette[i] = parsed_color;
                             } else {
                                 return Err(ConfigReadError::ColorParseErr(format!(
@@ -393,7 +400,6 @@ pub fn parse_config(toml: &toml::Table) -> ConfigParseResult<CliConfig> {
             }
         }
     }
-
     Ok(conf)
 }
 

--- a/cli/src/config/default_cfg.toml
+++ b/cli/src/config/default_cfg.toml
@@ -16,43 +16,43 @@ show_connections = true
 
 [display.icons]
 
-[[display.icons.arm]]
+[display.icons.arm]
 icon = "+--"
 color = "FFFFFF"
 
-[[display.icons.arm_last]]
+[display.icons.arm_last]
 icon = "+--"
 color = "FFFFFF"
 
-[[display.icons.arm_multiparent]]
+[display.icons.arm_multiparent]
 icon = "+.."
 color = "FFFFFF"
 
-[[display.icons.arm_multiparent_last]]
+[display.icons.arm_multiparent_last]
 icon = "+.."
 color = "FFFFFF"
 
-[[display.icons.arm_bar]]
+[display.icons.arm_bar]
 icon = "|"
 color = "FFFFFF"
 
-[[display.icons.node_none]]
+[display.icons.node_none]
 icon = "[ ]"
 color = "cyan"
 
-[[display.icons.node_checked]]
+[display.icons.node_checked]
 icon = "[x]"
 color = "green"
 
-[[display.icons.node_partial]]
+[display.icons.node_partial]
 icon = "[~]"
 color = "orange"
 
-[[display.icons.node_pseudo]]
+[display.icons.node_pseudo]
 icon = "[*]"
 color = "yellow"
 
-[[display.icons.node_date]]
+[display.icons.node_date]
 icon = "[#]"
 color = "purple"
 
@@ -61,7 +61,7 @@ color = "purple"
 # Unplanned
 # start_of_week: sun   # only sun or mon is supported
 
-[[display.calendar.heatmap]]
+[display.calendar.heatmap]
 
 # Heatmap for the calendar.
 palette = [

--- a/cli/src/config/default_cfg.toml
+++ b/cli/src/config/default_cfg.toml
@@ -1,0 +1,77 @@
+# Default Configuration for tuecli
+
+[graph]
+# Automatically trim unused indices after each graph-related operations.
+auto_clean = false
+
+[display]
+# Date format used for date nodes
+date_fmt = "%Y-%m-%d"
+
+# Print info when a node is added/removed/linked/unlinked.
+show_connections = true
+
+# Unplanned
+# show_completion_status = true
+
+[display.icons]
+
+[[display.icons.arm]]
+icon = "+--"
+color = "FFFFFF"
+
+[[display.icons.arm_last]]
+icon = "+--"
+color = "FFFFFF"
+
+[[display.icons.arm_multiparent]]
+icon = "+.."
+color = "FFFFFF"
+
+[[display.icons.arm_multiparent_last]]
+icon = "+.."
+color = "FFFFFF"
+
+[[display.icons.arm_bar]]
+icon = "|"
+color = "FFFFFF"
+
+[[display.icons.node_none]]
+icon = "[ ]"
+color = "cyan"
+
+[[display.icons.node_checked]]
+icon = "[x]"
+color = "green"
+
+[[display.icons.node_partial]]
+icon = "[~]"
+color = "orange"
+
+[[display.icons.node_pseudo]]
+icon = "[*]"
+color = "yellow"
+
+[[display.icons.node_date]]
+icon = "[#]"
+color = "purple"
+
+[[display.calendar]]
+
+# Unplanned
+# start_of_week: sun   # only sun or mon is supported
+
+[[display.calendar.heatmap]]
+
+# Heatmap for the calendar.
+palette = [
+  "5A7EDE", # Least amount of finished tasks
+  "785EF0",
+  "DC267F",
+  "FE6100",
+  "E0A729" # Most amount of finished tasks
+]
+
+# Unplanned
+# [defaults]
+# parent = "today"

--- a/cli/src/config/defaults.rs
+++ b/cli/src/config/defaults.rs
@@ -1,0 +1,52 @@
+//! Baked-in defaults for the tuecli's configuration.
+
+use crate::display::{Color, ColorEnum};
+
+pub const DEFAULT_HEATMAP_PALETTE: [Color; 5] = [
+    Color::new(90, 126, 222), // #5A7EDE
+    Color::new(120, 94, 240), // #785EF0
+    Color::new(220, 38, 127), // #DC267F
+    Color::new(254, 97, 0),   // #FE6100
+    Color::new(224, 167, 41), // #E0A729
+];
+
+// Graph section
+pub const DEFAULT_GRAPH_AUTO_CLEAN: bool = false;
+
+// Display section
+pub const DEFAULT_DATE_FORMAT: &str = "%Y-%m-%d";
+pub const DEFAULT_SHOW_CONNECTIONS: bool = true;
+
+// Icons - arms
+pub const DEFAULT_ICON_ARM: &str = "+--";
+pub const DEFAULT_COLOR_ARM: Color = Color::new(255, 255, 255); // #FFFFFF
+
+pub const DEFAULT_ICON_ARM_LAST: &str = "+--";
+pub const DEFAULT_COLOR_ARM_LAST: Color = Color::new(255, 255, 255); // #FFFFFF
+
+pub const DEFAULT_ICON_ARM_MULTIPARENT: &str = "+..";
+pub const DEFAULT_COLOR_ARM_MULTIPARENT: Color = Color::new(255, 255, 255); // #FFFFFF
+//
+pub const DEFAULT_ICON_ARM_MULTIPARENT_LAST: &str = "+..";
+pub const DEFAULT_COLOR_ARM_MULTIPARENT_LAST: Color = Color::new(255, 255, 255); // #FFFFFF
+
+pub const DEFAULT_ICON_ARM_BAR: &str = "|";
+pub const DEFAULT_COLOR_ARM_BAR: Color = Color::new(255, 255, 255); // #FFFFFF
+
+// Icons - nodes
+pub const DEFAULT_ICON_NODE_NONE: &str = "[ ]";
+pub const DEFAULT_COLOR_NODE_NONE: ColorEnum = ColorEnum::Cyan;
+
+pub const DEFAULT_ICON_NODE_CHECKED: &str = "[x]";
+pub const DEFAULT_COLOR_NODE_CHECKED: ColorEnum = ColorEnum::Green;
+
+pub const DEFAULT_ICON_NODE_PARTIAL: &str = "[~]";
+pub const DEFAULT_COLOR_NODE_PARTIAL: ColorEnum = ColorEnum::Orange;
+
+pub const DEFAULT_ICON_NODE_PSEUDO: &str = "[*]";
+pub const DEFAULT_COLOR_NODE_PSEUDO: ColorEnum = ColorEnum::Yellow;
+
+pub const DEFAULT_ICON_NODE_DATE: &str = "[#]";
+pub const DEFAULT_COLOR_NODE_DATE: ColorEnum = ColorEnum::Purple;
+
+pub const DEFAULT_CONFIG: &str = include_str!("default_cfg.toml");

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -1,4 +1,3 @@
-
 use chrono::{Datelike, NaiveDate};
 use colored::Colorize;
 use tuecore::graph::node::task::{TaskData, TaskState};
@@ -17,10 +16,12 @@ pub struct Color {
 }
 
 impl Color {
+    /// Creates a new color.
     pub(crate) const fn new(r: u8, g: u8, b: u8) -> Self {
         Self { r, g, b }
     }
 
+    /// Convert from hex code formatted color to `Color`.
     pub(crate) fn from_hex(hex: &str) -> AppResult<Self> {
         if hex.len() != 6 {
             return Err(crate::AppError::ParseError("Error parsing color: hex color must be 6 digits".into()));
@@ -33,6 +34,7 @@ impl Color {
         Ok(Color { r, g, b })
     }
 
+    /// Turn color into a tuple of r, g, and b values.
     fn tup(&self) -> (u8, u8, u8) {
         (self.r, self.g, self.b)
     }
@@ -89,239 +91,87 @@ impl Default for Color {
     }
 }
 
-struct Displayer<'a> {
-    config: &'a CliConfig
+pub struct Displayer<'a> {
+    config: &'a CliConfig,
 }
 
-pub fn aliases_title() -> String {
-    format!("{}", "Aliases:".bold())
-}
-
-pub fn parents_title() -> String {
-    format!("Node has more than one parents, please specify the parent!\n{}", "List of parents:".bold())
-}
-pub fn display_id(idx: usize, alias: Option<&str>) -> String {
-    if let Some(alias) = alias {
-        format!("{}:{}", idx.to_string().bright_green(), alias.bright_blue())
-    } else {
-        format!("{}", idx.to_string().bright_green())
+impl<'a> Displayer<'a> {
+    pub fn new(config: &'a CliConfig) -> Self {
+        Self {
+            config,
+        }
     }
-}
 
-fn display_task_data(task_data: &TaskData) -> String {
+    pub fn aliases_title(&self) -> String {
+        format!("{}", "Aliases:".bold())
+    }
+
+
+    pub fn parents_title(&self) -> String {
+        format!("Node has more than one parents, please specify the parent!\n{}", "List of parents:".bold())
+    }
+
+    pub fn display_id(&self, idx: usize, alias: Option<&str>) -> String {
+        if let Some(alias) = alias {
+            format!("{}:{}", idx.to_string().bright_green(), alias.bright_blue())
+        } else {
+            format!("{}", idx.to_string().bright_green())
+        }
+    }
+
+    fn display_task_data(&self, task_data: &TaskData) -> String {
         match task_data.state {
             TaskState::None => return " ".to_string(),
             TaskState::Partial => return "~".to_string(),
             TaskState::Done => return "x".to_string()
         }
-}
-
-fn display_nodetype(node_type: &NodeType) -> String {
-    match node_type {
-        NodeType::Task(data) => display_task_data(data),
-        NodeType::Date(_) => return "#".to_string(),
-        NodeType::Pseudo => return "*".to_string(),
     }
-}
 
-fn display_node(node: &Node) -> String {
-    let index = if let Some(ref alias) = node.metadata.alias {
-        format!("({}:{})", node.metadata.index, alias)
-    } else {
-            format!("({})", node.metadata.index)
-        }
-        .bright_blue();
-    let state = format!("{}{}{}", "[".bright_blue(), display_nodetype(&node.data), "]".bright_blue());
-
-    let dim = node.metadata.archived;
-
-    if let NodeType::Date(data) = &node.data {
-        let title = if node.title.is_empty() {
-        " ".to_string()
-        } else {
-            format!(" {} ", node.title.clone())
-        };
-        if dim {
-            format!("{} {}{}{}", state, format!("[{}]", data.date.format("%Y-%m-%d")).dimmed(), title.dimmed(), index)
-        } else {
-            format!("{} {}{}{}", state, format!("[{}]", data.date.format("%Y-%m-%d")).dimmed(), title, index)
-        }
-    } else {
-        if dim {
-            format!("{} {} {}", state, node.title.dimmed(), index)
-        } else {
-            format!("{} {} {}", state, node.title, index)
+    fn display_nodetype(&self, node_type: &NodeType) -> String {
+        match node_type {
+            NodeType::Task(data) => self.display_task_data(data),
+            NodeType::Date(_) => return "#".to_string(),
+            NodeType::Pseudo => return "*".to_string(),
         }
     }
-}
 
-pub fn print_removal(idx: usize, recursive: bool) {
-    if recursive {
-        println!("Removed node {} and its children.", idx.to_string().bright_blue());
-
+    fn fmt_node(&self, node: &Node) -> String {
+        let index = if let Some(ref alias) = node.metadata.alias {
+            format!("({}:{})", node.metadata.index, alias)
         } else {
-        println!("Removed node {}.", idx.to_string().bright_blue());
-    }
-}
+                format!("({})", node.metadata.index)
+            }
+            .bright_blue();
+        let state = format!("{}{}{}", "[".bright_blue(), self.display_nodetype(&node.data), "]".bright_blue());
 
-pub fn print_link_dates(from: usize, connect: bool) {
-    let from = format!("({})", from).bright_blue();
-    if connect {
-        println!("{} -> {}", from, "(dates)".bright_blue());
-    } else {
-        println!("{} -x- {}", from, "(dates)".bright_blue());
-    }
-}
+        let dim = node.metadata.archived;
 
-pub fn print_link_root(from: usize, connect: bool) {
-    let from = format!("({})", from).bright_blue();
-    if connect {
-        println!("{} -> {}", from, "(root)".bright_blue());
-    } else {
-        println!("{} -x- {}", from, "(root)".bright_blue());
-    }
-}
-
-pub fn print_link(from: usize, to: usize, connect: bool) {
-    let from = format!("({})", from).bright_blue();
-    let to = format!("({})", to).bright_blue();
-    if connect {
-        println!("{} -> {}", from, to);
-    } else {
-        println!("{} -x- {}", from, to);
-    }
-}
-
-pub fn days_in_month(year: i32, month: u32) -> i64 {
-    NaiveDate::from_ymd_opt(
-        match month {
-            12 => year + 1,
-            _ => year
-
-        },
-        match month {
-            12 => 1,
-            _ => month + 1,
-        },
-        1,
-    ).unwrap()
-    .signed_duration_since(NaiveDate::from_ymd_opt(year, month, 1).unwrap())
-    .num_days()
-}
-
-const HEATMAP_PALLETE: [(u8, u8, u8); 5] = [(58, 80, 162), (120, 94, 240), (220, 38, 127), (254, 97, 0), (255, 176, 0)];
-
-fn print_heatmap() {
-    print!("\x1B[6A"); // up
-    print!("\x1B[24C"); // right
-    print!("finished");
-    print!("\x1B[9D"); // left
-    print!("\x1B[1B"); // down
-    for i in 0..5 {
-        print!("{}", "  ".on_custom_color(HEATMAP_PALLETE[i]));
-    }
-    print!("\x1B[11D"); // left
-    print!("\x1B[1B"); // down
-    print!("less    more");
-    print!("\x1B[4B\r"); // down
-
-}
-
-pub fn print_calendar(graph: &Graph, date: &NaiveDate) -> AppResult<()> {
-    println!("Calendar: {} {}", date.format("%B").to_string().bold(), date.format("%Y").to_string().green());
-
-    for i in ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"] {
-        print!("{}", i.yellow());
-        print!(" ");
-    }
-
-    let days_in_month = days_in_month(date.year(), date.month()) as u32;
-
-    // HACK: i don't know why datetime is so unnecessarily hard here?!??!! please fix below
-    let nd = NaiveDate::from_ymd_opt(date.year(), date.month(), 1).unwrap();
-    let first_day = nd.format("%u").to_string().parse::<u32>().unwrap() % 7;
-
-    print!("\n");
-
-    let days: Vec<u32> = (1..=days_in_month+first_day).into_iter().collect();
-    for i in days {
-        if i > first_day {
-            let curr_date = i - first_day;
-            if let Ok(idx) = graph.get_date_index(&NaiveDate::from_ymd_opt(date.year(), date.month(), curr_date).unwrap()) {
-                let node = graph.get_node(idx);
-                let finished = node.metadata.children.iter().filter(|idx| {
-                    let node = graph.get_node(**idx);
-                    if let NodeType::Task(data) = node.data {
-                        data.state == TaskState::Done
-                    } else {
-                        false
-                    }
-                }).count();
-                let total_nodes = node.metadata.children.iter().filter(|idx| {
-                    let node = graph.get_node(**idx);
-                    if let NodeType::Task(_) = node.data {
-                        true
-                    } else {
-                        false
-                    }
-                }).count();
-
-                let range_finished = if total_nodes == 0 {
-                    0
-                } else {
-                    finished * 4 / total_nodes
-                };
-
-                let color = HEATMAP_PALLETE[range_finished];
-
-                if curr_date == date.day() {
-                    print!("{} ", format!("{:02}", curr_date).bold().underline().on_custom_color(color));
-                } else {
-                    print!("{} ", format!("{:02}", curr_date).on_custom_color(color));
-
-                }
+        if let NodeType::Date(data) = &node.data {
+            let title = if node.title.is_empty() {
+                " ".to_string()
             } else {
-                    print!("{} ", format!("{:02}", curr_date).dimmed());
+                format!(" {} ", node.title.clone())
+            };
+            if dim {
+                format!("{} {}{}{}", state, format!("[{}]", data.date.format("%Y-%m-%d")).dimmed(), title.dimmed(), index)
+            } else {
+                format!("{} {}{}{}", state, format!("[{}]", data.date.format("%Y-%m-%d")).dimmed(), title, index)
             }
         } else {
-            print!("   ");
-        }
-        if i % 7 == 0 {
-            print!("\n");
+            if dim {
+                format!("{} {} {}", state, node.title.dimmed(), index)
+            } else {
+                format!("{} {} {}", state, node.title, index)
+            }
         }
     }
 
-    print!("\n");
-
-    print_heatmap();
-    Ok(())
-
-}
-
-/// CLI display methods.
-pub trait CLIDisplay {
-    fn display_node(node: &Node, depth: u32, last: bool);
-
-    fn print_tree_indent(depth: u32, dots: bool);
-
-    fn list_roots(&self, max_depth: u32, show_archived: bool) -> AppResult<()>;
-
-    fn list_archived(&self) -> AppResult<()>;
-
-    fn list_dates(&self, skip_archived: bool) -> AppResult<()>;
-
-    fn list_children(&self, target: usize, max_depth: u32, show_archived: bool) -> AppResult<()>;
-
-    fn print_stats(&self, target: Option<usize>) -> AppResult<()>;
-}
-
-impl CLIDisplay for Graph {
-    fn display_node(node: &Node, depth: u32, last: bool) {
-        Graph::print_tree_indent(depth, node.metadata.parents.len() > 1);
-        println!("{}", display_node(node));
+    pub fn display_node(&self, node: &Node, depth: u32, last: bool) {
+        self.print_tree_indent(depth, node.metadata.parents.len() > 1);
+        println!("{}", self.fmt_node(node));
     }
 
-    fn print_tree_indent(depth: u32, dots: bool) {
+    pub fn print_tree_indent(&self, depth: u32, dots: bool) {
         if depth == 0 {
             return;
         }
@@ -336,107 +186,250 @@ impl CLIDisplay for Graph {
         }
     }
 
-    fn list_roots(&self, max_depth: u32, show_archived: bool) -> AppResult<()> {
-        self.traverse_recurse(
-            self.get_root_nodes_indices(),
+    pub fn list_roots(&self, graph: &Graph, max_depth: u32, show_archived: bool) -> AppResult<()> {
+        graph.traverse_recurse(
+            graph.get_root_nodes_indices(),
             show_archived,
             max_depth,
             1,
             None,
-            &mut |node, depth, last| Self::display_node(node, depth-1, last),
+            &mut |node, depth, last| self.display_node(node, depth-1, last),
         )?;
         Ok(())
     }
 
-    fn list_archived(&self) -> AppResult<()> {
-        self.traverse_recurse(
-            self.get_archived_node_indices(),
+    pub fn list_archived(&self, graph: &Graph) -> AppResult<()> {
+        graph.traverse_recurse(
+            graph.get_archived_node_indices(),
             true,
             1,
             1,
             None,
-            &mut |node, depth, last| Self::display_node(node, depth-1, last),
+            &mut |node, depth, last| self.display_node(node, depth-1, last),
         )?;
         Ok(())
     }
 
-    fn list_dates(&self, skip_archived: bool) -> AppResult<()> {
-        let dates: Vec<usize> = self.get_date_nodes_indices().iter()
-            .filter(|idx| !self.get_node(**idx).metadata.archived || skip_archived)
+    pub fn list_dates(&self, graph: &Graph, skip_archived: bool) -> AppResult<()> {
+        let dates: Vec<usize> = graph.get_date_nodes_indices().iter()
+            .filter(|idx| !graph.get_node(**idx).metadata.archived || skip_archived)
             .map(|x| *x).collect();
-        self.traverse_recurse(dates.as_slice(), false, 1, 1, None,
-            &mut |node, depth, last| { Self::display_node(node, depth-1, last) })?;
+        graph.traverse_recurse(dates.as_slice(), false, 1, 1, None,
+            &mut |node, depth, last| { self.display_node(node, depth-1, last) })?;
         Ok(())
     }
 
-    fn list_children(&self, target: usize, max_depth: u32, show_archived: bool) -> AppResult<()> {
+    pub fn list_children(&self, graph: &Graph, target: usize, max_depth: u32, show_archived: bool) -> AppResult<()> {
         // Display self as well
-        self.with_node(target, &mut |node| Self::display_node(node, 0, false));
+        graph.with_node(target, &mut |node| self.display_node(node, 0, false));
 
-        self.traverse_recurse(
-            self.get_node_children(target).as_slice(),
+        graph.traverse_recurse(
+            graph.get_node_children(target).as_slice(),
             show_archived,
             max_depth,
             1,
             Some(target),
-            &mut |node, depth, last| Self::display_node(node, depth, last),
+            &mut |node, depth, last| self.display_node(node, depth, last),
         )?;
         Ok(())
     }
 
-    fn print_stats(&self, target: Option<usize>) -> AppResult<()> {
+    pub fn print_stats(&self, graph: &Graph, target: Option<usize>) -> AppResult<()> {
         // If a specific node is specified
         if let Some(target) = target {
-            let node = self.get_nodes()[target].as_ref().unwrap().borrow();
+            let node = graph.get_nodes()[target].as_ref().unwrap().borrow();
             println!("ID      : {}", target);
             println!("Message : {}", &node.title);
             println!("Parents :");
             for i in &node.metadata.parents {
-                let parent = self.get_nodes()[*i].as_ref().unwrap().borrow();
+                let parent = graph.get_nodes()[*i].as_ref().unwrap().borrow();
                 println!(
                     "({}) {} [{}]",
-                    parent.metadata.index, parent.title, display_nodetype(&parent.data)
+                    parent.metadata.index, parent.title, self.display_nodetype(&parent.data)
                 );
             }
             println!("Children:");
             for i in &node.metadata.children {
-                let child = self.get_nodes()[*i].as_ref().unwrap().borrow();
+                let child = graph.get_nodes()[*i].as_ref().unwrap().borrow();
                 println!(
                     "({}) {} [{}]",
-                    child.metadata.index, child.title, display_nodetype(&child.data)
+                    child.metadata.index, child.title, self.display_nodetype(&child.data)
                 );
             }
             if let Some(ref alias) = node.metadata.alias {
                 println!("Alias   : {}", alias);
             }
             println!("Archived: {}", node.metadata.archived);
-            println!("Status  : [{}]", display_nodetype(&node.data));
+            println!("Status  : [{}]", self.display_nodetype(&node.data));
 
         // Else, list out stats for the whole graph
         } else {
             println!(
                 "Nodes   : {} (Empty: {})",
-                self.get_nodes().len(),
-                self.get_nodes()
+                graph.get_nodes().len(),
+                graph.get_nodes()
                     .iter()
                     .fold(0, |acc, x| if x.is_none() { acc + 1 } else { acc })
             );
             println!(
                 "Edges   : {}",
-                self.get_nodes()
+                graph.get_nodes()
                     .iter()
                     .fold(0, |acc, x| if let Some(x) = x {
                         acc + x.borrow().metadata.parents.len()
                     } else {
                         acc
                     })
-                    + self.get_roots().len()
+                    + graph.get_roots().len()
             );
-            println!("Roots   : {}", self.get_roots().len());
-            println!("Dates   : {}", self.get_dates().len());
-            println!("Aliases : {}", self.get_aliases().len());
-            println!("Archived: {}", self.get_archived().len());
+            println!("Roots   : {}", graph.get_roots().len());
+            println!("Dates   : {}", graph.get_dates().len());
+            println!("Aliases : {}", graph.get_aliases().len());
+            println!("Archived: {}", graph.get_archived().len());
         }
         Ok(())
     }
+
+    fn print_heatmap(&self) {
+        print!("\x1B[6A"); // up
+        print!("\x1B[24C"); // right
+        print!("finished");
+        print!("\x1B[9D"); // left
+        print!("\x1B[1B"); // down
+        for i in 0..5 {
+            print!("{}", "  ".on_custom_color(self.config.display.calendar_config.heatmap_palette[i].tup()));
+        }
+        print!("\x1B[11D"); // left
+        print!("\x1B[1B"); // down
+        print!("less    more");
+        print!("\x1B[4B\r"); // down
+
+    }
+
+    pub fn print_calendar(&self, graph: &Graph, date: &NaiveDate) -> AppResult<()> {
+        println!("Calendar: {} {}", date.format("%B").to_string().bold(), date.format("%Y").to_string().green());
+
+        for i in ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"] {
+            print!("{}", i.yellow());
+            print!(" ");
+        }
+
+        let days_in_month = self.days_in_month(date.year(), date.month()) as u32;
+
+        // HACK: i don't know why datetime is so unnecessarily hard here?!??!! please fix below
+        let nd = NaiveDate::from_ymd_opt(date.year(), date.month(), 1).unwrap();
+        let first_day = nd.format("%u").to_string().parse::<u32>().unwrap() % 7;
+
+        print!("\n");
+
+        let days: Vec<u32> = (1..=days_in_month+first_day).into_iter().collect();
+        for i in days {
+            if i > first_day {
+                let curr_date = i - first_day;
+                if let Ok(idx) = graph.get_date_index(&NaiveDate::from_ymd_opt(date.year(), date.month(), curr_date).unwrap()) {
+                    let node = graph.get_node(idx);
+                    let finished = node.metadata.children.iter().filter(|idx| {
+                        let node = graph.get_node(**idx);
+                        if let NodeType::Task(data) = node.data {
+                            data.state == TaskState::Done
+                        } else {
+                            false
+                        }
+                    }).count();
+                    let total_nodes = node.metadata.children.iter().filter(|idx| {
+                        let node = graph.get_node(**idx);
+                        if let NodeType::Task(_) = node.data {
+                            true
+                        } else {
+                            false
+                        }
+                    }).count();
+
+                    let range_finished = if total_nodes == 0 {
+                        0
+                    } else {
+                        finished * 4 / total_nodes
+                    };
+
+                    let color = self.config.display.calendar_config.heatmap_palette[range_finished].tup();
+
+                    if curr_date == date.day() {
+                        print!("{} ", format!("{:02}", curr_date).bold().underline().on_custom_color(color));
+                    } else {
+                        print!("{} ", format!("{:02}", curr_date).on_custom_color(color));
+
+                    }
+                } else {
+                    print!("{} ", format!("{:02}", curr_date).dimmed());
+                }
+            } else {
+                print!("   ");
+            }
+            if i % 7 == 0 {
+                print!("\n");
+            }
+        }
+
+        print!("\n");
+
+        self.print_heatmap();
+        Ok(())
+
+    }
+
+
+    pub fn print_removal(&self, idx: usize, recursive: bool) {
+        if recursive {
+            println!("Removed node {} and its children.", idx.to_string().bright_blue());
+
+        } else {
+            println!("Removed node {}.", idx.to_string().bright_blue());
+        }
+    }
+
+    pub fn print_link_dates(&self, from: usize, connect: bool) {
+        let from = format!("({})", from).bright_blue();
+        if connect {
+            println!("{} -> {}", from, "(dates)".bright_blue());
+        } else {
+            println!("{} -x- {}", from, "(dates)".bright_blue());
+        }
+    }
+
+    pub fn print_link_root(&self, from: usize, connect: bool) {
+        let from = format!("({})", from).bright_blue();
+        if connect {
+            println!("{} -> {}", from, "(root)".bright_blue());
+        } else {
+            println!("{} -x- {}", from, "(root)".bright_blue());
+        }
+    }
+
+    pub fn print_link(&self, from: usize, to: usize, connect: bool) {
+        let from = format!("({})", from).bright_blue();
+        let to = format!("({})", to).bright_blue();
+        if connect {
+            println!("{} -> {}", from, to);
+        } else {
+            println!("{} -x- {}", from, to);
+        }
+    }
+
+    pub fn days_in_month(&self, year: i32, month: u32) -> i64 {
+        NaiveDate::from_ymd_opt(
+            match month {
+                12 => year + 1,
+                _ => year
+
+            },
+            match month {
+                12 => 1,
+                _ => month + 1,
+            },
+            1,
+        ).unwrap()
+            .signed_duration_since(NaiveDate::from_ymd_opt(year, month, 1).unwrap())
+            .num_days()
+    }
+
 }

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -4,7 +4,7 @@ use tuecore::graph::node::task::{TaskData, TaskState};
 use tuecore::graph::node::{Node, NodeType};
 use tuecore::graph::{Graph, GraphGetters};
 
-use crate::config::CliConfig;
+use crate::config::{CliConfig, DEFAULT_CONFIG};
 use crate::{AppError, AppResult};
 
 /// A struct representing 24-bit color.
@@ -460,6 +460,10 @@ impl<'a> Displayer<'a> {
         ).unwrap()
             .signed_duration_since(NaiveDate::from_ymd_opt(year, month, 1).unwrap())
             .num_days()
+    }
+
+    pub fn template_cfg(&self) -> &'static str {
+        DEFAULT_CONFIG
     }
 
 }

--- a/cli/src/errors.rs
+++ b/cli/src/errors.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 use tuecore::graph;
 use tuecore::doc;
 
+use crate::config::ConfigReadError;
+
 #[derive(Error)]
 pub(crate) enum AppError {
     #[error("Graph error: {0}")]
@@ -35,7 +37,13 @@ pub(crate) enum AppError {
     DateParseError(#[from] ParseDateTimeError),
 
     #[error("Failed to get node index: {0}")]
-    IndexRetrievalError(String)
+    IndexRetrievalError(String),
+
+    #[error("Parse error: {0}")]
+    ParseError(String),
+
+    #[error("Configuration error: {0}")]
+    ConfigError(#[from] ConfigReadError),
 }
 
 // The default Debug implementation displays the enum like so:

--- a/cli/src/graph.rs
+++ b/cli/src/graph.rs
@@ -89,6 +89,7 @@ impl CLIGraphOps for Graph {
 
         Ok(())
     }
+
     fn mv(&mut self, from: usize, to: usize) -> AppResult<()> {
         self.clean_parents(from)?;
         self.link(to, from)?;

--- a/cli/src/graph.rs
+++ b/cli/src/graph.rs
@@ -1,7 +1,7 @@
 //! This module contains graph operations that are only used by the CLI front-end.
 
 use tuecore::graph::{node::NodeType, Graph, GraphGetters};
-use crate::{dates::parse_datetime_extended, display::print_link, AppError, AppResult};
+use crate::{dates::parse_datetime_extended, AppError, AppResult};
 
 pub trait CLIGraphOps {
     fn get_index_cli(&self, id: &str, assume_date: bool) -> AppResult<usize>;
@@ -73,8 +73,6 @@ impl CLIGraphOps for Graph {
         if let NodeType::Task(data) = source_node.data {
             self.set_task_state(new_node, data.state, true)?;
         };
-
-        print_link(from, to, true);
 
         Ok(new_node)
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -42,7 +42,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 if config.display.show_connections {
                     displayer.print_link_root(idx, true);
                 }
-                return Ok(());
             } else if let Some(when) = date {
                 let date = parse_datetime_extended(when)?;
 
@@ -55,7 +54,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 if config.display.show_connections {
                     displayer.print_link_dates(idx, true);
                 }
-                return Ok(());
             } 
 
             let message = sub_matches
@@ -72,7 +70,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
             if config.display.show_connections {
                 displayer.print_link(to, parent, true);
             }
-            Ok(())
         }
         Some(("rm", sub_matches)) => {
             let ids = sub_matches.get_many::<String>("ID").expect("ID required");
@@ -89,7 +86,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                     displayer.print_removal(node_id, recursive);
                 }
             }
-            Ok(())
         }
         Some(("link", sub_matches)) => {
             let assume_date_1 = sub_matches.get_flag("assumedate1");
@@ -111,7 +107,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
             if config.display.show_connections {
                 displayer.print_link(child, parent, true);
             }
-            Ok(())
         }
         Some(("unlink", sub_matches)) => {
             let assume_date_1 = sub_matches.get_flag("assumedate1");
@@ -133,7 +128,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
             if config.display.show_connections {
                 displayer.print_link(parent, child, false);
             }
-            Ok(())
         }
         Some(("mv", sub_matches)) => {
             let assume_date_1 = sub_matches.get_flag("assumedate1");
@@ -155,7 +149,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                     displayer.print_link(node, parent, true);
                 }
             }
-            Ok(())
         }
         Some(("set", sub_matches)) => {
             let assume_date = sub_matches.get_flag("assumedate");
@@ -164,7 +157,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 .get_one::<TaskState>("state")
                 .expect("node state required");
             graph.set_task_state(id, *state, true)?;
-            Ok(())
         }
         Some(("check", sub_matches)) => {
             let assume_date = sub_matches.get_flag("assumedate");
@@ -173,7 +165,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 let id = graph.get_index_cli(id, assume_date)?;
                 graph.set_task_state(id, TaskState::Done, true)?;
             }
-            Ok(())
         }
         Some(("uncheck", sub_matches)) => {
             let assume_date = sub_matches.get_flag("assumedate");
@@ -182,7 +173,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 let id = graph.get_index_cli(id, assume_date)?;
                 graph.set_task_state(id, TaskState::None, true)?;
             }
-            Ok(())
         }
         Some(("arc", sub_matches)) => {
             let assume_date = sub_matches.get_flag("assumedate");
@@ -191,7 +181,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 let id = graph.get_index_cli(id, assume_date)?;
                 graph.set_archived(id, true)?;
             }
-            Ok(())
         }
         Some(("unarc", sub_matches)) => {
             let assume_date = sub_matches.get_flag("assumedate");
@@ -200,7 +189,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 let id = graph.get_index_cli(id, assume_date)?;
                 graph.set_archived(id, false)?;
             }
-            Ok(())
         }
         Some(("alias", sub_matches)) => {
             let assume_date = sub_matches.get_flag("assumedate");
@@ -209,7 +197,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 .get_one::<String>("alias")
                 .expect("alias required");
             graph.set_alias(id, alias.clone())?;
-            Ok(())
         }
         Some(("unalias", sub_matches)) => {
             let assume_date = sub_matches.get_flag("assumedate");
@@ -218,7 +205,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 let id = graph.get_index_cli(id, assume_date)?;
                 graph.unset_alias(id)?;
             }
-            Ok(())
         }
         Some(("aliases", _)) => {
             let aliases = graph.get_aliases();
@@ -230,7 +216,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
             } else {
                 println!("No added alias.");
             }
-            Ok(())
         }
         Some(("rename", sub_matches)) => {
             let assume_date = sub_matches.get_flag("assumedate");
@@ -239,7 +224,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 .get_one::<String>("message")
                 .expect("ID required");
             graph.rename_node(id, message.to_string())?;
-            Ok(())
         }
         Some(("ls", sub_matches)) => {
             let assume_date = sub_matches.get_flag("assumedate");
@@ -257,16 +241,13 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 None => displayer.list_roots(graph, depth, show_archived)?,
                 Some(id) => displayer.list_children(graph, graph.get_index_cli(&id, assume_date)?, depth, show_archived)?,
             }
-            Ok(())
         }
         Some(("lsd", sub_matches)) => {
             let show_archived = sub_matches.get_flag("archived");
             displayer.list_dates(graph, show_archived)?;
-            Ok(())
         }
         Some(("lsa", _)) => {
             displayer.list_archived(graph)?;
-            Ok(())
         }
         Some(("rand", sub_matches)) => {
             let assume_date = sub_matches.get_flag("assumedate");
@@ -313,19 +294,17 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                     displayer.print_stats(graph, Some(*child))?;
                 }
             };
-            Ok(())
         }
         Some(("stats", sub_matches)) => {
             let assume_date = sub_matches.get_flag("assumedate");
             if let Some(id) = sub_matches.get_one::<String>("ID") {
-                displayer.print_stats(graph, Some(graph.get_index_cli( id, assume_date)?))
+                displayer.print_stats(graph, Some(graph.get_index_cli( id, assume_date)?))?;
             } else {
-                displayer.print_stats(graph, None)
-            }
+                displayer.print_stats(graph, None)?;
+            };
         }
         Some(("clean", _)) => {
             graph.clean();
-            Ok(())
         }
         Some(("cal", sub_matches)) => {
             let date_str = sub_matches.get_one::<String>("date");
@@ -388,7 +367,6 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 }
             }
 
-            Ok(())
         }
         Some(("ord", sub_matches)) => {
             let assume_date_1 = sub_matches.get_flag("assumedate1");
@@ -422,16 +400,15 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
                 if parents.len() > 1 {
                     println!("{}", displayer.parents_title());
 
-                    for id in parents {
-                        let node = graph.get_node(id);
+                    for id in &parents {
+                        let node = graph.get_node(*id);
                         if let Some(alias) = node.metadata.alias {
-                            println!("* {} ({})", displayer.display_id(id, Some(&alias)), node.title);
+                            println!("* {} ({})", displayer.display_id(*id, Some(&alias)), node.title);
                         } else {
-                            println!("* {} ({})", displayer.display_id(id, None), node.title);
+                            println!("* {} ({})", displayer.display_id(*id, None), node.title);
 
                         }
                     }
-                    return Ok(())
                 }
                 parent_idx = parents[0];
             }
@@ -439,12 +416,18 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
             match *direction {
                 OrderingDirection::Up => graph.reorder_node_delta(node_idx, parent_idx, -(*count as i32))?,
                 OrderingDirection::Down => graph.reorder_node_delta(node_idx, parent_idx, *count as i32)?,
-            }
+            };
 
-            Ok(())
         }
-        _ => Err(AppError::InvalidSubcommand),
+        _ => return Err(AppError::InvalidSubcommand),
+    };
+
+    // TODO: maybe dont run this every time?
+    if config.graph.auto_clean {
+        graph.clean();
     }
+
+    Ok(())
 }
 
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, clap::ValueEnum)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -419,6 +419,10 @@ fn handle_command<'a>(matches: &ArgMatches, graph: &mut Graph, config: &CliConfi
             };
 
         }
+        Some(("dump-cfg", _)) => {
+            println!("{}", displayer.template_cfg());
+
+        }
         _ => return Err(AppError::InvalidSubcommand),
     };
 
@@ -589,6 +593,9 @@ fn cli() -> AppResult<Command> {
             .arg(arg!(date: [date] "Date to use (only the month will be considered)")
                 .value_parser(value_parser!(String))
                 .default_value("today"))
+        )
+        .subcommand(Command::new("new-cfg")
+            .about("Dump a default configuration file. Recommended: run then redirect and save to ~/.tueconf.toml")
         )
     )
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,6 +2,7 @@ mod display;
 mod errors;
 mod dates;
 mod graph;
+mod config;
 
 use std::path::PathBuf;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,2 @@
-pub mod config;
 pub mod doc;
 pub mod graph;


### PR DESCRIPTION
Implement configuration support for `tuecli` using `toml`.

This configuration implementation supports configuring:
- `auto_clean`: auto-cleaning graph
- `date_fmt`: date format to show when listing with `lsd`
- `show_connections`: whether to print connection messages or not
- `display`: miscellaneous display configuration (icons and calendar heatmap palette)